### PR TITLE
Added support for TypeScript debugging

### DIFF
--- a/web.config
+++ b/web.config
@@ -26,6 +26,7 @@
             <!-- Configure site to serve JSON files -->
             <remove fileExtension=".json" />
             <mimeMap fileExtension=".json" mimeType="application/json" />
+            <mimeMap fileExtension=".ts" mimeType="application/x-typescript" />
         </staticContent>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
When site is not authorized to serve TS files, the debugger shows a blank file for mapped TS files